### PR TITLE
Update install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Script to retrieve a list of repositories for a given GitHub user for [gh](https
 ## Install
 
 ```bash
-gh extension eggplants/gh-matome
+gh extension install eggplants/gh-matome
 ```
 
 ## Run


### PR DESCRIPTION
This PR update the docs on how to install this extension.
The current install instruction does not work, missing the `install` command.